### PR TITLE
Fixed kerrythai returns year format 'YYYY' instead of 'YY' and more

### DIFF
--- a/lib/courier/kerrythai.js
+++ b/lib/courier/kerrythai.js
@@ -43,7 +43,7 @@ var parser = {
         location: locationMessage,
         message: message,
         status: tracker.STATUS.IN_TRANSIT,
-        time: moment($el.find('.date').text().trim().replace(/\s+Time/i, '').replace(/Date /i, '') + '+07:00', 'DD MMM YY HH:mmZZ').format()
+        time: moment($el.find('.date').text().trim().replace(/\s+Time/i, '').replace(/Date /i, ''), 'DD MMM YYYY HH:mm').format('YYYY-MM-DD HH:mm')
       }
       if (/delivery successful/i.test(statusMessage) === true) {
         checkpoint.status = tracker.STATUS.DELIVERED


### PR DESCRIPTION
- kerrythai returns year format 'YYYY' instead of 'YY' 
- no need to add timezone (I've tested on Heroku in Europe region and everything works fine)
- no need to add 'second' because kerrythai don't return it. 

#hacktoberfest