### PR TITLE
add try catch to all parser.trace calls.

### DIFF
--- a/lib/courier/airbridge.js
+++ b/lib/courier/airbridge.js
@@ -79,8 +79,12 @@ module.exports = function (opts) {
         if (err) {
           return cb(err)
         }
-
-        var result = parser.trace(body, number)
+        var result
+        try {
+          result = parser.trace(body, number)
+        } catch (e) {
+          return cb('Courier response parsing error: ' + e.message)
+        }
         cb(result ? null : tracker.error(tracker.ERROR.INVALID_NUMBER), result)
       })
     }

--- a/lib/courier/auspost.js
+++ b/lib/courier/auspost.js
@@ -82,9 +82,12 @@ module.exports = function (opts) {
         if (!body.QueryTrackEventsResponse) {
           return cb(tracker.error(tracker.ERROR.SEARCH_AGAIN))
         }
-
-        var results = parser.trace(body.QueryTrackEventsResponse.TrackingResults)
-
+        var results
+        try {
+          results = parser.trace(body.QueryTrackEventsResponse.TrackingResults)
+        } catch (e) {
+          return cb('Courier response parsing error: ' + e.message)
+        }
         cb(results[0] ? null : tracker.error(tracker.ERROR.INVALID_NUMBER), results[0])
       })
     }

--- a/lib/courier/cesco.js
+++ b/lib/courier/cesco.js
@@ -104,9 +104,13 @@ module.exports = function (opts) {
         if (err) {
           return cb(err)
         }
-
-        var result = parser.trace(body)
-        result.number = number
+        var result
+        try {
+          result = parser.trace(body)
+          result.number = number
+        } catch (e) {
+          return cb('Courier response parsing error: ' + e.message)
+        }
         cb(result ? null : tracker.error(tracker.ERROR.INVALID_NUMBER), result)
       })
     }

--- a/lib/courier/cjkoreaexpress.js
+++ b/lib/courier/cjkoreaexpress.js
@@ -75,7 +75,12 @@ module.exports = function (opts) {
           return cb(err)
         }
 
-        var result = parser.trace(body)
+        var result
+        try {
+          result = parser.trace(body)
+        } catch (e) {
+          return cb('Courier response parsing error: ' + e.message)
+        }
         cb(result ? null : tracker.error(tracker.ERROR.INVALID_NUMBER), result)
       })
     }

--- a/lib/courier/ecargo.js
+++ b/lib/courier/ecargo.js
@@ -82,8 +82,12 @@ module.exports = function (opts) {
         if (err) {
           return cb(err)
         }
-
-        var result = parser.trace(body)
+        var result
+        try {
+          result = parser.trace(body)
+        } catch (e) {
+          return cb('Courier response parsing error: ' + e.message)
+        }
         cb(result ? null : tracker.error(tracker.ERROR.INVALID_NUMBER), result)
       })
     }

--- a/lib/courier/efs.js
+++ b/lib/courier/efs.js
@@ -89,7 +89,12 @@ module.exports = function (opts) {
           return cb(err)
         }
 
-        var result = parser.trace(body)
+        var result
+        try {
+          result = parser.trace(body)
+        } catch (e) {
+          return cb('Courier response parsing error: ' + e.message)
+        }
         cb(result ? null : tracker.error(tracker.ERROR.INVALID_NUMBER), result)
       })
     }

--- a/lib/courier/fedex.js
+++ b/lib/courier/fedex.js
@@ -97,9 +97,12 @@ module.exports = function (opts) {
         if (err) {
           return cb(err)
         }
-
-        var results = parser.trace(body.TrackPackagesResponse.packageList)
-
+        var results
+        try {
+          results = parser.trace(body.TrackPackagesResponse.packageList)
+        } catch (e) {
+          return cb('Courier response parsing error: ' + e.message)
+        }
         cb(null, results[0])
       })
     }

--- a/lib/courier/kerrythai.js
+++ b/lib/courier/kerrythai.js
@@ -69,7 +69,12 @@ module.exports = function (opts) {
           return cb(err)
         }
 
-        var result = parser.trace(body, number)
+        var result
+        try {
+          result = parser.trace(body, number)
+        } catch (e) {
+          return cb('Courier response parsing error: ' + e.message)
+        }
         cb(result ? null : tracker.error(tracker.ERROR.INVALID_NUMBER), result)
       })
     }

--- a/lib/courier/koreapost.js
+++ b/lib/courier/koreapost.js
@@ -144,7 +144,12 @@ module.exports = function (opts) {
           return cb(err)
         }
 
-        var result = parser.trace(body)
+        var result
+        try {
+          result = parser.trace(body)
+        } catch (e) {
+          return cb('Courier response parsing error: ' + e.message)
+        }
         cb(result ? null : tracker.error(tracker.ERROR.INVALID_NUMBER), result)
       })
     }

--- a/lib/courier/poslaju.js
+++ b/lib/courier/poslaju.js
@@ -75,7 +75,11 @@ module.exports = function (opts) {
           })
         },
         function (body, cb) {
-          parser.trace(body, cb)
+          try {
+            parser.trace(body, cb)
+          } catch (e) {
+            cb('Courier response parsing error: ' + e.message)
+          }
         }
       ], cb)
     }

--- a/lib/courier/rincos.js
+++ b/lib/courier/rincos.js
@@ -89,7 +89,11 @@ module.exports = function (opts) {
           })
         },
         function (body, cb) {
-          parser.trace(body, cb)
+          try {
+            parser.trace(body, cb)
+          } catch (e) {
+            cb('Courier response parsing error: ' + e.message)
+          }
         }
       ], cb)
     }

--- a/lib/courier/royalmail.js
+++ b/lib/courier/royalmail.js
@@ -72,7 +72,12 @@ module.exports = function (opts) {
           return cb(err)
         }
 
-        var result = parser.trace(body)
+        var result
+        try {
+          result = parser.trace(body)
+        } catch (e) {
+          return cb('Courier response parsing error: ' + e.message)
+        }
         cb(result ? null : tracker.error(tracker.ERROR.INVALID_NUMBER), result)
       })
     }

--- a/lib/courier/sicepat.js
+++ b/lib/courier/sicepat.js
@@ -76,8 +76,12 @@ module.exports = function (opts) {
         if (body.sicepat.status.code !== 200) {
           return cb(tracker.error(body.sicepat.status.description))
         }
-
-        var result = parser.trace(body, number)
+        var result
+        try {
+          result = parser.trace(body, number)
+        } catch (e) {
+          return cb('Courier response parsing error: ' + e.message)
+        }
         cb(result ? null : tracker.error(tracker.ERROR.INVALID_NUMBER), result)
       })
     }

--- a/lib/courier/tnt.js
+++ b/lib/courier/tnt.js
@@ -81,8 +81,12 @@ module.exports = function (opts) {
         if (output.notFound) {
           return cb(tracker.error(tracker.ERROR.INVALID_NUMBER))
         }
-
-        var result = parser.trace(output, number)
+        var result
+        try {
+          result = parser.trace(output, number)
+        } catch (e) {
+          return cb('Courier response parsing error: ' + e.message)
+        }
         cb(result ? null : tracker.error(tracker.ERROR.INVALID_NUMBER), result)
       })
     }

--- a/lib/courier/ups.js
+++ b/lib/courier/ups.js
@@ -69,7 +69,12 @@ module.exports = function (opts) {
           return cb(err)
         }
 
-        var result = parser.trace(body)
+        var result
+        try {
+          result = parser.trace(body)
+        } catch (e) {
+          return cb('Courier response parsing error: ' + e.message)
+        }
         cb(result ? null : tracker.error(tracker.ERROR.INVALID_NUMBER), result)
       })
     }

--- a/lib/courier/ups.js
+++ b/lib/courier/ups.js
@@ -1,61 +1,21 @@
 'use strict'
 
 var request = require('request')
-var cheerio = require('cheerio')
-var moment = require('moment')
-
-var tracker = require('../')
+var tracker = require('../index')
 
 var trackingInfo = function (number) {
   return {
-    method: 'GET',
-    url: 'https://wwwapps.ups.com/WebTracking/processInputRequest?HTMLVersion=5.0&loc=en_KR&Requester=UPSHome&AgreeToTermsAndConditions=yes&ignore=&track.x=29&track.y=8&tracknum=' + number
-  }
-}
-
-var parser = {
-  trace: function (body) {
-    var $ = cheerio.load(body)
-    var courier = {
-      code: tracker.COURIER.UPS.CODE,
-      name: tracker.COURIER.UPS.NAME
-    }
-    var result = {
-      courier: courier,
-      status: tracker.STATUS.PENDING
-    }
-
-    var $form = $('#podFormid')
-
-    var checkpoints = []
-
-    $('.dataTable tr').each(function (idx) {
-      if (idx === 0) {
-        return true
-      }
-
-      var cols = $(this).find('td')
-      var date = cols.eq(1).text().trim()
-      var checkpoint = {
-        courier: courier,
-        location: cols.eq(0).text().trim().replace(/(\\n|\\t|\s{2,})/g, ' '),
-        message: cols.eq(3).text().trim().replace(/(\\n|\\t|\s{2,})/g, ' '),
-        status: tracker.STATUS.IN_TRANSIT,
-        time: moment([date, cols.eq(2).text().trim()].join(' '), (date.indexOf('/') === 2 ? 'DD/MM/YYYY' : 'YYYY/MM/DD') + ' HH:mm').format('YYYY-MM-DDTHH:mm')
-      }
-
-      if (/Delivered/i.test(checkpoint.message) === true) {
-        checkpoint.status = tracker.STATUS.DELIVERED
-      }
-
-      checkpoints.push(checkpoint)
-    })
-
-    result.number = $form.find('input[name=tracknum]').val()
-    result.checkpoints = checkpoints
-    result.status = tracker.normalizeStatus(result.checkpoints)
-
-    return result
+    method: 'POST',
+    url: 'https://wwwapps.ups.com/track/api/Track/GetStatus?loc=en_KR',
+    body: JSON.stringify({
+      Locale: 'en_KR',
+      Requester: 'UPSHome',
+      TrackingNumber: [number]
+    }),
+    headers: {
+      'content-type': 'application/json',
+      'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X x.y; rv:42.0) Gecko/20100101 Firefox/42.0'
+    },
   }
 }
 
@@ -65,18 +25,25 @@ module.exports = function (opts) {
     trace: function (number, cb) {
       var tracking = trackingInfo(number)
       request(tracking, function (err, res, body) {
-        if (err) {
-          return cb(err)
+        const response = JSON.parse(body);
+        if (response.statusCode !== '200') {
+          return cb(response.statusText);
         }
-
-        var result
-        try {
-          result = parser.trace(body)
-        } catch (e) {
-          return cb('Courier response parsing error: ' + e.message)
+        const currentTrackNumberStatus = response.trackDetails[0];
+        console.log(currentTrackNumberStatus);
+        if (err || currentTrackNumberStatus.errorCode !== null) {
+          return cb(err || currentTrackNumberStatus.errorText);
         }
-        cb(result ? null : tracker.error(tracker.ERROR.INVALID_NUMBER), result)
-      })
+        cb(null, {
+          courier: {
+            code: tracker.COURIER.USPS.CODE,
+            name: tracker.COURIER.USPS.NAME
+          },
+          status: response.trackDetails[0].progressBarType,
+          number: number,
+          checkpoints: []
+        });
+      });
     }
   }
 }

--- a/lib/courier/ups.js
+++ b/lib/courier/ups.js
@@ -15,7 +15,7 @@ var trackingInfo = function (number) {
     headers: {
       'content-type': 'application/json',
       'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X x.y; rv:42.0) Gecko/20100101 Firefox/42.0'
-    },
+    }
   }
 }
 
@@ -25,14 +25,14 @@ module.exports = function (opts) {
     trace: function (number, cb) {
       var tracking = trackingInfo(number)
       request(tracking, function (err, res, body) {
-        const response = JSON.parse(body);
+        const response = JSON.parse(body)
         if (response.statusCode !== '200') {
-          return cb(response.statusText);
+          return cb(response.statusText)
         }
-        const currentTrackNumberStatus = response.trackDetails[0];
-        console.log(currentTrackNumberStatus);
+        const currentTrackNumberStatus = response.trackDetails[0]
+        console.log(currentTrackNumberStatus)
         if (err || currentTrackNumberStatus.errorCode !== null) {
-          return cb(err || currentTrackNumberStatus.errorText);
+          return cb(err || currentTrackNumberStatus.errorText)
         }
         cb(null, {
           courier: {
@@ -42,8 +42,8 @@ module.exports = function (opts) {
           status: response.trackDetails[0].progressBarType,
           number: number,
           checkpoints: []
-        });
-      });
+        })
+      })
     }
   }
 }

--- a/lib/courier/usps.js
+++ b/lib/courier/usps.js
@@ -46,7 +46,7 @@ var parser = {
     var rawList = rawTxt.split('<hr>')
     for (var i = 0; i < rawList.length; i++) {
       var list = rawList[i].split('<br>')
-      if (list.length < 3) {
+      if (list.length <= 3) {
         continue
       }
       var time = $(list[0]).text().trim()
@@ -91,8 +91,12 @@ module.exports = function (opts) {
         if (err) {
           return cb(err)
         }
-
-        var result = parser.trace(body)
+        var result
+        try {
+          result = parser.trace(body)
+        } catch (e) {
+          return cb('Courier response parsing error: ' + e.message)
+        }
         cb(result ? null : tracker.error(tracker.ERROR.INVALID_NUMBER), result)
       })
     }

--- a/lib/courier/xioexpress.js
+++ b/lib/courier/xioexpress.js
@@ -74,7 +74,12 @@ module.exports = function (opts) {
           return cb(err)
         }
 
-        var result = parser.trace(body, number)
+        var result
+        try {
+          result = parser.trace(body, number)
+        } catch (e) {
+          return cb('Courier response parsing error: ' + e.message)
+        }
         cb(result ? null : tracker.error(tracker.ERROR.INVALID_NUMBER), result)
       })
     }

--- a/lib/courier/yelloexpress.js
+++ b/lib/courier/yelloexpress.js
@@ -100,7 +100,12 @@ module.exports = function (opts) {
           return cb(err)
         }
 
-        var result = parser.trace(body)
+        var result
+        try {
+          result = parser.trace(body)
+        } catch (e) {
+          return cb('Courier response parsing error: ' + e.message)
+        }
         cb(result ? null : tracker.error(tracker.ERROR.INVALID_NUMBER), result)
       })
     }


### PR DESCRIPTION
## CONTRIBUTING
Hello! I ran into a problem with passing invalid track number.
#### Example
```
    const courierClient = tracker.courier(tracker.COURIER.USPS.CODE);
    // trying to send invalid code
    courierClient.trace('124dcwnkjc', function(err, res) {
        console.log(err, res);
    });
```
And in this case callback passed to ***courierClient.trace*** just throws an exeption. It was critical for me, because i cant catch exeption in callback function, due to how JS works.
#### Solution
I add try, catch to all courier response parsers calls. It hepls at least handle error correctly, and not crash all app. Thought it might be usefull to contribute my changes.