### PR TITLE
Update usps.js

### DIFF
--- a/lib/courier/usps.js
+++ b/lib/courier/usps.js
@@ -46,7 +46,7 @@ var parser = {
     var rawList = rawTxt.split('<hr>')
     for (var i = 0; i < rawList.length; i++) {
       var list = rawList[i].split('<br>')
-      if (list.length < 3) {
+      if (list.length < 4) {
         continue
       }
       var time = $(list[0]).text().trim()


### PR DESCRIPTION
The condition for the USPS should be list.length < 4, since sometimes location can be empty and hence location is omitted from the list.

![image](https://user-images.githubusercontent.com/57438672/72976781-3bf0a880-3df9-11ea-8fe7-0ee807d2fd34.png)
