### PR TITLE
Replace Travis CI with Github Actions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,0 +1,29 @@
+# This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+
+name: Node.js CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [10.x, 12.x, 14.x, 15.x]
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: npm install
+    - run: npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-language: node_js
-node_js:
-  - "12.18.3"
-  - "10.22.0"
-before_script:
-  - npm install grunt-cli -g

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # delivery-tracker
 
 [![version](https://img.shields.io/npm/v/delivery-tracker.svg)](https://www.npmjs.com/package/delivery-tracker) [![download](https://img.shields.io/npm/dm/delivery-tracker.svg)](https://www.npmjs.com/package/delivery-tracker)
-[![status status](https://travis-ci.org/egg-/delivery-tracker.svg?branch=master)](https://travis-ci.org/egg-/delivery-tracker)
+[![status status](https://github.com/egg-/delivery-tracker/workflows/Node.js%20CI/badge.svg)](https://github.com/egg-/delivery-tracker/actions)
 [![Standard - JavaScript Style Guide](https://img.shields.io/badge/code%20style-standard-brightgreen.svg)](http://standardjs.com/)
 
 delivery-tracker is delivery tracking library for Node.js


### PR DESCRIPTION
Dear egg-,
Dear maintainers,

As Github Actions has evolved to a viable alternative to Travis, and the recent discussions around the new Travis CI pricing system, I am proposing switching to Github Actions for build testing. Github actions is completely free for public projects, see https://github.com/features/actions.

In this small PR, I have added a simple config for Github actions, which ran beautifully in my fork (around 30 seconds total).
This config should do the same as Travis is/was doing here, build & test commits to `master` and pull requests to `master`.

Best regards,
MindSolve