### PR TITLE
Added "eta" to fedex results.

### DIFF
--- a/lib/courier/fedex.js
+++ b/lib/courier/fedex.js
@@ -39,6 +39,7 @@ var normalize = function (item) {
     courier: courier,
     number: item.displayTrackingNbr,
     status: tracker.STATUS.PENDING,
+    eta: item.estDeliveryDt,
     checkpoints: []
   }
 


### PR DESCRIPTION
There is a plethora of useful data that FedEx passes via the API.  This one I find particularly useful and wanted it added to the base code. 
Polling the result's "estDeliveryDt" value we can now use FedEx's own estimation calculations to better predict package arrival instead of just reading the current status checkpoints.  Obviously, this data is subject to change as exceptions occur but I feel its inclusion is far more beneficial than leaving it out.

If the time is 00:00:00 then the ETA is "by end of day" otherwise it is a set ETA value.

tl;dr
Added "eta" value to FedEx results.  Value is in ISO 8601 format