### PR TITLE
Added try/catch to catch error when UPS site is down

### DIFF
--- a/lib/courier/ups.js
+++ b/lib/courier/ups.js
@@ -53,7 +53,11 @@ module.exports = function (opts) {
         }
         var token = parser.token(res.headers['set-cookie'] || [])
         req(tracking.detail(token), function (err, res, body) {
-          var response = JSON.parse(body)
+          try {
+            var response = JSON.parse(body)
+          } catch (error) {
+            return cb(error)
+          }
           if (response.statusCode !== '200') {
             return cb(response.statusText)
           }


### PR DESCRIPTION
I noticed that the UPS site was down earlier this morning, and it caused my app using this package to crash with the following error. I'm not 100% sure that this solves the issue, since the UPS site came back before I could actually test if this would allow me to catch the error and prevent a crash. 

```
<HTML><HEAD>
^

SyntaxError: Unexpected token < in JSON at position 0
    at JSON.parse (<anonymous>)
    at Request._callback (/.../node_modules/delivery-tracker/lib/courier/ups.js:56:31)
    at Request.self.callback (/.../node_modules/request/request.js:185:22)
    at Request.emit (events.js:210:5)
    at Request.<anonymous> (/.../node_modules/request/request.js:1154:10)
    at Request.emit (events.js:210:5)
    at IncomingMessage.<anonymous> (/.../node_modules/request/request.js:1076:12)
    at Object.onceWrapper (events.js:299:28)
    at IncomingMessage.emit (events.js:215:7)
    at endReadableNT (_stream_readable.js:1183:12)
```

