### PR TITLE
Fix USPS scraping as of 09-2022

### DIFF
--- a/lib/courier/usps.js
+++ b/lib/courier/usps.js
@@ -25,54 +25,28 @@ var parser = {
       number: $('input[name=label]').val(),
       status: tracker.STATUS.PENDING
     }
-    var toText = function (txt) {
-      if (!txt) {
-        return ''
-      }
-      return $(txt.indexOf('<span>') !== -1 ? txt : '<span>' + txt + '</span>').text().trim()
-    }
 
     var checkpoints = []
+    var $history = $('.tracking-progress-bar-status-container').find('.tb-step')
 
-    var $history = $('#trackingHistory_1').find('.panel-actions-content')
-    $('.mobileOnly').remove()
-
-    // html -> txt
-    var rawTxt = $history.html()
-    if (!rawTxt) {
-      return false
-    }
-    rawTxt = rawTxt.replace(/\s+/g, ' ')
-    // txt -> history list
-    var rawList = rawTxt.split('<hr>')
-    for (var i = 0; i < rawList.length; i++) {
-      var list = rawList[i].split('<br>')
-      if (list.length <= 3) {
-        continue
-      }
-      var time = $(list[0]).text().trim()
-      var statusMessage = toText(list[1])
-      var location = toText(list[2])
-      var message = [statusMessage]
-
-      if ((list[3] || '').trim().length > 0) {
-        message.push(toText(list[3]))
-      }
+    $history.each((index, element) => {
+      if (element.attribs?.class.indexOf('toggle-history-container') !== -1)
+        return
 
       var checkpoint = {
         courier: courier,
-        location: location,
-        message: message.join(' - '),
+        location: $(element).find('.tb-location').text().trim(),
+        message: $(element).find('.tb-status-detail').text(),
         status: tracker.STATUS.IN_TRANSIT,
         // November 17, 2017, 3:08 pm
-        time: moment(time, 'MMMM DD, YYYY, hh:mm a').format('YYYY-MM-DDTHH:mm')
+        time: moment($(element).find('.tb-date').text().trim(), 'MMMM DD, YYYY, hh:mm a').format('YYYY-MM-DDTHH:mm')
       }
 
       checkpoint.message.indexOf('Shipping Label Created') !== -1 && (checkpoint.status = tracker.STATUS.INFO_RECEIVED)
       checkpoint.message.indexOf('Delivered') !== -1 && (checkpoint.status = tracker.STATUS.DELIVERED)
 
       checkpoints.push(checkpoint)
-    }
+    })
 
     result.checkpoints = checkpoints
     result.status = tracker.normalizeStatus(result.checkpoints)


### PR DESCRIPTION
The USPS recently updated their tracking page design. This PR uses the history list to correctly parse checkpoints

Example showing new design: https://tools.usps.com/go/TrackConfirmAction?qtc_tLabels1=9400108205496039945323 

![image](https://user-images.githubusercontent.com/1429672/190923078-507b3af7-db65-4c16-ace1-7f6ddf5446cd.png)
