### PR TITLE
Fix UPS and USPS time parsing

### DIFF
--- a/lib/courier/ups.js
+++ b/lib/courier/ups.js
@@ -88,7 +88,8 @@ module.exports = function (opts) {
               location: current.location,
               message: current.activityScan.trim(),
               status: tracker.STATUS.IN_TRANSIT,
-              time: moment([current.date, current.time].join(' '), 'MM/DD/YYYY HH:mm').format('YYYY-MM-DDTHH:mmZ')
+              // 10/20/2020 3:17 A.M.
+              time: moment([current.date, current.time].join(' '), 'MM/DD/YYYY h:mm a').format('YYYY-MM-DDTHH:mmZ')
             }
 
             if (checkpoint.message.indexOf('DELIVERED') !== -1) {

--- a/lib/courier/usps.js
+++ b/lib/courier/usps.js
@@ -42,9 +42,9 @@ var parser = {
         location: $(element).find('.tb-location').text().trim(),
         message: $(element).find('.tb-status-detail').text(),
         status: tracker.STATUS.IN_TRANSIT,
-        // November 17, 2017, 3:08 pm
+        // November 17,      2017,  3:08 pm
         time: moment(
-          $(element).find('.tb-date').text().trim(),
+          $(element).find('.tb-date').text().replace(/\s+/g, ' ').trim(),
           'MMMM DD, YYYY, hh:mm a'
         ).format('YYYY-MM-DDTHH:mm')
       }


### PR DESCRIPTION
Bug fixes:
- Fix the UPS tracker incorrectly parsing the 12-hour time component due to missing 'a' token
- Fix the USPS tracker not parsing time correctly due to extra spaces in the middle of the time string

